### PR TITLE
fix for existing users logging from frontend

### DIFF
--- a/plugins/user/privacyconsent/privacyconsent.php
+++ b/plugins/user/privacyconsent/privacyconsent.php
@@ -109,8 +109,9 @@ class PlgUserPrivacyconsent extends JPlugin
 	{
 		// Check that the privacy is checked if required ie only in registration from frontend.
 		$option = $this->app->input->getCmd('option');
+		$form   = $this->app->input->post->get('jform', array(), 'array');
 
-		if ($this->app->isClient('site') && (!$data['privacyconsent']['privacy']) || (!$data['privacyconsent']['privacy']) && $option === 'com_admin')
+		if ($this->app->isClient('site') && (!$form['privacyconsent']['privacy']) || (!$form['privacyconsent']['privacy']) && $option === 'com_admin')
 		{
 			throw new InvalidArgumentException(JText::_('PLG_USER_PRIVACY_FIELD_ERROR'));
 		}

--- a/plugins/user/privacyconsent/privacyconsent.php
+++ b/plugins/user/privacyconsent/privacyconsent.php
@@ -87,7 +87,6 @@ class PlgUserPrivacyconsent extends JPlugin
 
 		if (is_object($data))
 		{
-
 			$userId = isset($data->id) ? $data->id : 0;
 
 			if ($userId > 0)
@@ -99,8 +98,8 @@ class PlgUserPrivacyconsent extends JPlugin
 					->select($db->quoteName('profile_value'))
 					->from($db->quoteName('#__user_profiles'))
 					->where($db->quoteName('user_id') . ' = ' . (int) $userId)
-					->where($db->quoteName('profile_key') . ' LIKE ' . $db->quote('consent'))
-					->order($db->quoteName('ordering') . ' ASC');
+					->where($db->quoteName('profile_key') . ' = ' . $db->quote('consent'))
+					->where($db->quoteName('profile_value') . ' = ' . $db->quote('1'));
 				$db->setQuery($query);
 
 				try
@@ -114,7 +113,7 @@ class PlgUserPrivacyconsent extends JPlugin
 					return false;
 				}
 
-				if (!empty($results[0]) == 1)
+				if (!empty($results[0]))
 				{
 					$form->removeField('privacy', 'privacyconsent');
 

--- a/plugins/user/privacyconsent/privacyconsent.php
+++ b/plugins/user/privacyconsent/privacyconsent.php
@@ -148,7 +148,12 @@ class PlgUserPrivacyconsent extends JPlugin
 		$option = $this->app->input->getCmd('option');
 		$form   = $this->app->input->post->get('jform', array(), 'array');
 
-		if ($this->app->isClient('site') && (!$form['privacyconsent']['privacy']) || (!$form['privacyconsent']['privacy']) && $option === 'com_admin')
+		if ($this->app->isClient('administrator'))
+		{
+			return true;
+		}
+
+		if (isset($form['privacyconsent']['privacy']) && (!$form['privacyconsent']['privacy']))
 		{
 			throw new InvalidArgumentException(JText::_('PLG_USER_PRIVACY_FIELD_ERROR'));
 		}

--- a/plugins/user/privacyconsent/privacyconsent.php
+++ b/plugins/user/privacyconsent/privacyconsent.php
@@ -145,7 +145,6 @@ class PlgUserPrivacyconsent extends JPlugin
 	public function onUserBeforeSave($user, $isNew, $data)
 	{
 		// Check that the privacy is checked if required ie only in registration from frontend.
-		$option = $this->app->input->getCmd('option');
 		$form   = $this->app->input->post->get('jform', array(), 'array');
 
 		if ($this->app->isClient('administrator'))

--- a/plugins/user/privacyconsent/privacyconsent.php
+++ b/plugins/user/privacyconsent/privacyconsent.php
@@ -85,6 +85,44 @@ class PlgUserPrivacyconsent extends JPlugin
 			'privacy',
 		);
 
+		if (is_object($data))
+		{
+
+			$userId = isset($data->id) ? $data->id : 0;
+
+			if ($userId > 0)
+			{
+				// Load the profile data from the database.
+				$db = JFactory::getDbo();
+
+				$query = $db->getQuery(true)
+					->select($db->quoteName('profile_value'))
+					->from($db->quoteName('#__user_profiles'))
+					->where($db->quoteName('user_id') . ' = ' . (int) $userId)
+					->where($db->quoteName('profile_key') . ' LIKE ' . $db->quote('consent'))
+					->order($db->quoteName('ordering') . ' ASC');
+				$db->setQuery($query);
+
+				try
+				{
+					$results = $db->loadRowList();
+				}
+				catch (RuntimeException $e)
+				{
+					$this->_subject->setError($e->getMessage());
+
+					return false;
+				}
+
+				if (!empty($results[0]) == 1)
+				{
+					$form->removeField('privacy', 'privacyconsent');
+
+					return true;
+				}
+			}
+		}
+
 		$privacyarticle	= $this->params->get('privacy_article');
 		$privacynote	= $this->params->get('privacy_note');
 


### PR DESCRIPTION
Pull Request for Issue # .
https://github.com/joomla/joomla-cms/pull/20051#issuecomment-380207363



### Testing Instructions
for existing users
when logging with an existing user you are  redirected to the edit profile 
 when you click on I agree on the privacy field
now  the profile submission is saved

