### PR TITLE
Improvement

### DIFF
--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -61,7 +61,7 @@ HTMLHelper::_('script', 'com_config/admin-application-default.min.js', ['version
 			<div class="tab-content" id="configContent">
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
 					<div class="tab-pane" id="<?php echo $name; ?>">
-						<?php echo $this->form->renderFieldset($name, $name === 'permissions' ? ['hiddenLabel' => true] : []); ?>
+						<?php echo $this->form->renderFieldset($name, $name === 'permissions' ? ['hiddenLabel' => true, 'class' => 'revert-controls'] : []); ?>
 					</div>
 				<?php endforeach; ?>
 			</div>

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -61,32 +61,7 @@ HTMLHelper::_('script', 'com_config/admin-application-default.min.js', ['version
 			<div class="tab-content" id="configContent">
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
 					<div class="tab-pane" id="<?php echo $name; ?>">
-						<?php if (isset($fieldSet->description) && !empty($fieldSet->description)) : ?>
-							<div class="alert alert-info">
-								<span class="icon-info" aria-hidden="true"></span> <?php echo Text::_($fieldSet->description); ?>
-							</div>
-						<?php endif; ?>
-						<?php foreach ($this->form->getFieldset($name) as $field) : ?>
-							<?php
-								$dataShowOn = '';
-								$groupClass = $field->type === 'Spacer' ? ' field-spacer' : '';
-							?>
-							<?php if ($field->showon) : ?>
-								<?php HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true)); ?>
-								<?php $dataShowOn = ' data-showon=\'' . json_encode(FormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\''; ?>
-							<?php endif; ?>
-							<?php if ($field->hidden) : ?>
-								<?php echo $field->input; ?>
-							<?php else : ?>
-								<div class="control-group<?php echo $groupClass; ?>"<?php echo $dataShowOn; ?>>
-									<?php if ($name != 'permissions') : ?>
-										<?php echo $field->renderField(); ?>
-									<?php else : ?>
-										<?php echo $this->form->getInput('rules'); ?>
-									<?php endif; ?>
-								</div>
-							<?php endif; ?>
-						<?php endforeach; ?>
+						<?php echo $this->form->renderFieldset($name, $name === 'permissions' ? ['hiddenLabel' => true] : []); ?>
 					</div>
 				<?php endforeach; ?>
 			</div>

--- a/administrator/templates/atum/scss/pages/_com_config.scss
+++ b/administrator/templates/atum/scss/pages/_com_config.scss
@@ -18,4 +18,8 @@
     padding: 1em;
     background-color: $white;
   }
+
+  .revert-controls .controls {
+    margin-left: 0;
+  }
 }


### PR DESCRIPTION
Removes code and prevents the double `control-group` stuff.

However comes with different issues on the permissions fields:

1. Your PR is missing if there's more than 1 field in the permissions fieldset.
2. Also in your current PR (but more unlikely practical use case) we've removed the ability to have a showon based on the permissions field (it technically existed before)

My PR has the issue that it fixes that but effectively reintroduces the `controls` class which means the permissions field is shifted left. So I gave it it's own class `revert-permissions` and overriding the `margin-left`. Not convinced it's amazing but it works :/