### PR TITLE
Some small corrections

### DIFF
--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -280,6 +280,9 @@ class CategoryModel extends ListModel
 			$menuParams = new Registry;
 		}
 
+		$mergedParams = clone $params;
+		$mergedParams->merge($menuParams);
+
 		// List state information
 		$format = $app->input->getWord('format');
 
@@ -289,7 +292,7 @@ class CategoryModel extends ListModel
 		}
 		else
 		{
-			$limit = $app->getUserStateFromRequest('com_contact.category.list', 'limit', $app->get('contacts_display_num'), 'uint');
+			$limit = $app->getUserStateFromRequest('com_contact.category.list', 'limit', $mergedParams->get('contacts_display_num', $app->get('list_limit')), 'uint');
 		}
 
 		$this->setState('list.limit', $limit);
@@ -302,7 +305,7 @@ class CategoryModel extends ListModel
 		$search = $app->getUserStateFromRequest('com_contact.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');
 		$this->setState('list.filter', $search);
 
-		$orderCol = $app->input->get('filter_order', $app->get('initial_sort', 'ordering'));
+		$orderCol = $app->input->get('filter_order', $mergedParams->get('initial_sort', 'ordering'));
 
 		if (!in_array($orderCol, $this->filter_fields))
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
With your current modification, the menu item parameters won't be merged with component parameters as expected

For example:

- In the com_contact Options, you set **# Contacts to List** parameter to 10
- In the menu item parameters, you set **# Contacts to List** to Use Global (10).

With that setup, you would expect that the system display 10 contacts when you click on the menu item but it is not, it is displaying all contacts (because $app->get('contacts_display_num') in your current code get parameter from menu item only, and it does not contain the value)

This PR just fixes that behavior.