### PR TITLE
Clean up double code for content_template_path

### DIFF
--- a/plugins/editors/tinymce/forms/setoptions.xml
+++ b/plugins/editors/tinymce/forms/setoptions.xml
@@ -72,7 +72,7 @@
 		label="PLG_TINY_FIELD_CUSTOM_CONTENT_TEMPLATE_PATH_LABEL"
 		description="PLG_TINY_FIELD_CUSTOM_CONTENT_TEMPLATE_PATH_DESC"
 		directory="/templates"
-		hide_default="true"
+		hide_none="true"
 		recursive="true"
 		exclude="system"
 		default=""

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -471,66 +471,40 @@ class PlgEditorTinymce extends CMSPlugin
 		if (!empty($allButtons['template']))
 		{
 			// Do we have a custom content_template_path
-			if (!empty($levelParams->get('content_template_path')))
+			$template_path = $levelParams->get('content_template_path');
+			$template_path = $template_path && $template_path != -1 ? '/templates/' . $template_path : '/media/vendor/tinymce/templates';
+
+			foreach (glob(JPATH_ROOT . $template_path . '/*.{html,txt}', GLOB_BRACE) as $filepath)
 			{
-				$content_template = '/templates/' . $levelParams->get('content_template_path') . '/';
-				foreach (glob(JPATH_ROOT . $content_template . '*.txt') as $filename)
+				$fileinfo      = pathinfo($filepath);
+				$filename      = $fileinfo['filename'];
+				$full_filename = $fileinfo['basename'];
+
+				if ($filename === 'index')
 				{
-					$filename = basename($filename, '.txt');
-
-					if ($filename !== 'index')
-					{
-						$lang        = Factory::getLanguage();
-						$title       = $filename;
-						$description = ' ';
-
-						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE'))
-						{
-							$title = Text::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE');
-						}
-
-						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC'))
-						{
-							$description = Text::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
-						}
-
-						$templates[] = array(
-							'title' => $title,
-							'description' => $description,
-							'url' => Uri::root(true) . $content_template . $filename . '.txt',
-						);
-					}
+					continue;
 				}
-			}
-			else
-			{
-				foreach (glob(JPATH_ROOT . '/media/vendor/tinymce/templates/*.html') as $filename)
+
+				$lang        = Factory::getLanguage();
+				$title       = $filename;
+				$title_upper = strtoupper($filename);
+				$description = ' ';
+
+				if ($lang->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE'))
 				{
-					$filename = basename($filename, '.html');
-
-					if ($filename !== 'index')
-					{
-						$lang        = Factory::getLanguage();
-						$title       = $filename;
-						$description = ' ';
-
-						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE'))
-						{
-							$title = Text::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE');
-						}
-
-						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC'))
-						{
-							$description = Text::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
-						}
-
-						$templates[] = array(
-							'title' => $title,
-							'description' => $description,
-							'url' => Uri::root(true) . '/media/vendor/tinymce/templates/' . $filename . '.html',
-						);
-					}
+					$title = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE');
 				}
+
+				if ($lang->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC'))
+				{
+					$description = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC');
+				}
+
+				$templates[] = array(
+					'title' => $title,
+					'description' => $description,
+					'url' => Uri::root(true) . $template_path . '/' . $full_filename,
+				);
 			}
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -472,7 +472,7 @@ class PlgEditorTinymce extends CMSPlugin
 		{
 			// Do we have a custom content_template_path
 			$template_path = $levelParams->get('content_template_path');
-			$template_path = $template_path && $template_path != -1 ? '/templates/' . $template_path : '/media/vendor/tinymce/templates';
+			$template_path = $template_path ? '/templates/' . $template_path : '/media/vendor/tinymce/templates';
 
 			foreach (glob(JPATH_ROOT . $template_path . '/*.{html,txt}', GLOB_BRACE) as $filepath)
 			{


### PR DESCRIPTION
This is what I have suggested in https://github.com/joomla/joomla-cms/pull/33130
Also I have fixed the bug when User "unselect" custom template path (then content_template_path is -1)