### PR TITLE
[CMS PR 36492] Fix wrong exception type and add back alert

### DIFF
--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Table\Extension;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
+use Joomla\Database\Exception\PrepareStatementFailureException;
 use Joomla\Database\ParameterType;
 
 /**
@@ -1210,7 +1211,7 @@ class Installer extends Adapter
 								{
 									$db->setQuery($query)->execute();
 								}
-								catch (ExecutionFailureException $e)
+								catch (ExecutionFailureException | PrepareStatementFailureException $e)
 								{
 									Log::add(Text::sprintf('JLIB_INSTALLER_UPDATE_LOG_QUERY', $file, $queryString), Log::INFO, 'Update');
 									Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), Log::INFO, 'Update');

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1213,9 +1213,15 @@ class Installer extends Adapter
 								}
 								catch (ExecutionFailureException | PrepareStatementFailureException $e)
 								{
+									$errorMessage = Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage());
+
+									// Log the error in the update log file
 									Log::add(Text::sprintf('JLIB_INSTALLER_UPDATE_LOG_QUERY', $file, $queryString), Log::INFO, 'Update');
-									Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), Log::INFO, 'Update');
+									Log::add($errorMessage, Log::INFO, 'Update');
 									Log::add(Text::_('JLIB_INSTALLER_SQL_END_NOT_COMPLETE'), Log::INFO, 'Update');
+
+									// Show the error message to the user
+									Log::add($errorMessage, Log::WARNING, 'jerror');
 
 									return false;
 								}


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/36492 .

### Summary of Changes

- Fix exception type in the catch to get the new logging when an SQL error happens in a new update SQL script.
- Add back the logging to jerror to get back the alert shown in backend.

### Testing Instructions

Add a new update SQL script with a version newer than the database schema version and which contains an SQL statement which causes an SQL error, e.g. an UPDATE statement for a not existing table, to the update package for PR #36492 and update a 4.0.x to that package.

### Actual result BEFORE applying this Pull Request

In backend no warning alert but an unhandled exception:

![j4 0-test-pr-36492-with-sql-error_before](https://user-images.githubusercontent.com/7413183/148650110-7876df10-3965-4853-b047-25d43b45ba50.png)

The log file does not contain the new logs added by PR #36492 .

When I fix the wrong exception type in the update package but don't add back the warning alert, I get:

![j4 0-test-pr-36492-with-sql-error_before_with-exception-fix](https://user-images.githubusercontent.com/7413183/148650199-82e21115-ab7f-4477-9223-30f8dfb42ac3.png)

### Expected result AFTER applying this Pull Request

In backend warning alert instead of unhandled exception:

![j4 0-test-pr-36492-with-sql-error_after_with-exception-fix](https://user-images.githubusercontent.com/7413183/148650165-dce933d0-fbd4-4502-a34b-f8173905f3b4.png)

The log file contains the new logs added by PR #36492 .

The misleading green success message will be handled by Nicholas' PR for 4.1-dev.

### Documentation Changes Required

None.