### PR TITLE
[4.3] Add guided tours to alternate menu preset

### DIFF
--- a/administrator/components/com_menus/presets/alternate.xml
+++ b/administrator/components/com_menus/presets/alternate.xml
@@ -350,6 +350,14 @@
 		/>
 
 		<menuitem
+			title="MOD_MENU_MANAGE_GUIDEDTOURS"
+			type="component"
+			element="com_guidedtours"
+			link="index.php?option=com_guidedtours&amp;view=tours"
+			permission="core.manage;com_guidedtours"
+		/>
+
+		<menuitem
 			title="COM_POSTINSTALL"
 			type="component"
 			element="com_postinstall"


### PR DESCRIPTION
This is a bug fix - not a new feature. It has already been tested and made RTC #40707 until it was broken by mistakenly treating it as a new feature

### Summary of Changes
Adds the guided tours component to the alternate menu preset 


### Testing Instructions
Go to the module manager and filter on admin modules
Open the admin menu module 
Change the preset from **Joomla Main Meunu** to **Alternative Main Menu**


### Actual result BEFORE applying this Pull Request
Guided Tours is not present in the components submenu


### Expected result AFTER applying this Pull Request

Guided tours is now available

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
