### PR TITLE
warning when run  mfa.cy.js

### DIFF
--- a/administrator/components/com_users/src/Model/BackupcodesModel.php
+++ b/administrator/components/com_users/src/Model/BackupcodesModel.php
@@ -252,7 +252,7 @@ class BackupcodesModel extends BaseDatabaseModel
          */
         $otherResult = false;
 
-        $temp1 = '';
+        $temp1 = [];
 
         for ($i = 0; $i < 10; $i++) {
             $temp1[$i] = random_int(0, 99999999);


### PR DESCRIPTION
for https://github.com/joomla/joomla-cms/pull/45169
if you want this should solve the other when run Mfa.cy.js

PHP Warning:  Only the first byte will be assigned to the string offset in C:\laragon\www\530\administrator\components\com_users\src\Model\BackupcodesModel.php on line 258

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
